### PR TITLE
MM-30708: Fix race in TestLdapConnect

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -120,7 +120,6 @@ func Dial(network, addr string) (*Conn, error) {
 		return nil, NewError(ErrorNetwork, err)
 	}
 	conn := NewConn(c, false)
-	conn.Start()
 	return conn, nil
 }
 
@@ -132,7 +131,6 @@ func DialTLS(network, addr string, config *tls.Config) (*Conn, error) {
 		return nil, NewError(ErrorNetwork, err)
 	}
 	conn := NewConn(c, true)
-	conn.Start()
 	return conn, nil
 }
 

--- a/ldap_test.go
+++ b/ldap_test.go
@@ -26,6 +26,7 @@ func TestDial(t *testing.T) {
 		t.Errorf(err.Error())
 		return
 	}
+	l.Start()
 	defer l.Close()
 	fmt.Printf("TestDial: finished...\n")
 }
@@ -37,6 +38,7 @@ func TestDialTLS(t *testing.T) {
 		t.Errorf(err.Error())
 		return
 	}
+	l.Start()
 	defer l.Close()
 	fmt.Printf("TestDialTLS: finished...\n")
 }
@@ -48,6 +50,7 @@ func TestStartTLS(t *testing.T) {
 		t.Errorf(err.Error())
 		return
 	}
+	l.Start()
 	err = l.StartTLS(&tls.Config{InsecureSkipVerify: true})
 	if err != nil {
 		t.Errorf(err.Error())
@@ -63,6 +66,7 @@ func TestTLSConnectionState(t *testing.T) {
 		t.Errorf(err.Error())
 		return
 	}
+	l.Start()
 	err = l.StartTLS(&tls.Config{InsecureSkipVerify: true})
 	if err != nil {
 		t.Errorf(err.Error())
@@ -87,6 +91,7 @@ func TestSearch(t *testing.T) {
 		t.Errorf(err.Error())
 		return
 	}
+	l.Start()
 	defer l.Close()
 
 	searchRequest := NewSearchRequest(
@@ -112,6 +117,7 @@ func TestSearchStartTLS(t *testing.T) {
 		t.Errorf(err.Error())
 		return
 	}
+	l.Start()
 	defer l.Close()
 
 	searchRequest := NewSearchRequest(
@@ -152,6 +158,7 @@ func TestSearchWithPaging(t *testing.T) {
 		t.Errorf(err.Error())
 		return
 	}
+	l.Start()
 	defer l.Close()
 
 	err = l.UnauthenticatedBind("")
@@ -227,6 +234,7 @@ func testMultiGoroutineSearch(t *testing.T, TLS bool, startTLS bool) {
 			t.Errorf(err.Error())
 			return
 		}
+		l.Start()
 		defer l.Close()
 	} else {
 		l, err = Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
@@ -234,6 +242,7 @@ func testMultiGoroutineSearch(t *testing.T, TLS bool, startTLS bool) {
 			t.Errorf(err.Error())
 			return
 		}
+		l.Start()
 		if startTLS {
 			fmt.Printf("TestMultiGoroutineSearch: using StartTLS...\n")
 			err := l.StartTLS(&tls.Config{InsecureSkipVerify: true})
@@ -281,6 +290,7 @@ func TestCompare(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	l.Start()
 	defer l.Close()
 
 	dn := "cn=math mich,ou=User Groups,ou=Groups,dc=umich,dc=edu"
@@ -303,6 +313,7 @@ func TestMatchDNError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	l.Start()
 	defer l.Close()
 
 	wrongBase := "ou=roups,dc=umich,dc=edu"


### PR DESCRIPTION
The core issue is that we are accessing the Debug field
after the connection reader has started.

There are 2 ways to solve this:
- Either we pass the Debug field in the constructor itself.
This would change signatures of Dial, DialTLS and NewConn.
It works but it does not look very good and is anyways an API change.
- We do not start the connection in Dial/DialTLS, but rather
start it by calling the Start method explicitly.

I have chosen the latter because functionally, it makes more sense to me.
Dial should just dial, and then we can use the Start method ourselves
after we have set up the struct to our liking.

Yes, this is a breaking change in functionality. But I don't see any other
way to do it without introducing an API change in any way. And this is
only used by us, and only in 2 places in the ldap code.

Once this goes in, we will need another PR in the EE codebase to change
the functionality and import the new code.

https://mattermost.atlassian.net/browse/MM-30708
